### PR TITLE
b5 repomap migrate

### DIFF
--- a/barney.context
+++ b/barney.context
@@ -1,0 +1,26 @@
+{
+	"version": 1,
+	"repomap": {
+		"barney.ci/alpine": {
+			"commit": "f2fa545e3fafa3387f2d7269721d16f3f499cc3b"
+		},
+		"barney.ci/barneyfile": {
+			"commit": "ed88c1c8bb4f634a5ec1b75578cd10a63dd31585"
+		},
+		"barney.ci/debian": {
+			"commit": "a8b990da6e74b41609db2a4233dc157378b3c213"
+		},
+		"barney.ci/golang": {
+			"commit": "d7f023afaa04440c08ad00296fe3dd01b7f5c437"
+		},
+		"barney.ci/model": {
+			"commit": "f11eb1e1459dd6ac88b10802d6e04bf3f6a93c7a"
+		},
+		"github.com/golang/go": {
+			"commit": "194de8fbfaf4c3ed54e1a3c1b14fc67a830b8d95"
+		},
+		"github.com/untangle/openwrt": {
+			"commit": "88c8fb9a702c80c545a6d61f768a3cac7b69ec3c"
+		}
+	}
+}


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/MFW-6040

Migrate repomap

I believe lack of it cause us to pull old version of barney.ci, which blocks BAR jobs pulling the repo to upstream