### PR TITLE
Add info about previous/obsolete names

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -98,4 +98,8 @@ x-github-bridge:
 
 x-bar:
   version: production
+
+ObsoleteNames:
+  - github.com/untangle/mfw_build
+
 epoch: 1


### PR DESCRIPTION
Scanning our repo metadata service I found a duplicated entry for the repo

```
"Reponame": "github.com/untangle/mfw_build"
```

and

```
 "Reponame": "code.arista.io/mfw/build"
```

To avoid errors and confusion I'm adding info about `ObsoleteNames` as in https://github.com/untangle/mfw_test/blob/master/meta.yaml#L42