### PR TITLE
EFW-463_schedule_travis-skip

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,11 +1,14 @@
 {
     "automergeSchedule": ["at any time"],
+    commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
 
     packageRules: [
         {
             "matchDatasources": ["custom.bar"],
             "matchPackageNames": ["code.arista.io/infra/barney/barnzilla-repos"],
-            "automergeSchedule": ["at any time"]
+            "automergeSchedule": ["* 0-3 * * *"],
+            "timezone": "Etc/UTC",
+            commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
         }
     ]
 }


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/EFW-463

I'm skipping Travis-ci for BAR updates and changing schedule for auto merge for barnzilla-repos
I on purpose, add the changes to repos under Untangle org that has no Travis checks in case we want to add them later