### PR TITLE
MFW-6516: Adding  support for  libelf-dev needed for openwrt 23.05 upgrade

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -27,6 +27,7 @@ RUN apt install -y wget
 RUN apt install -y zlib1g-dev
 RUN apt install -y python3-distutils-extra
 RUN apt install -y meson
+RUN apt install -y libelf-dev
 RUN apt clean
 RUN rm -rf /var/lib/apt/lists/* /var/cache/apt-show-versions/*
 


### PR DESCRIPTION
openwrt 23.05 requires libelf package to build while building kernel 5.15. 

followinf are the logs. As jenkins build are common for all branches. Need to check if PR works for 21.02 and 23.05 as well.
if not will revert

```
saves " HOSTCFLAGS="-O2 -I/home/mfw/openwrt/staging_dir/host/include  -Wall -Wmissing-prototypes -Wstrict-prototypes" CROSS_COMPILE="x86_64-openwrt-linux-musl-" ARCH="x86" KBUILD_HAVE_NLS=no KBUILD_BUILD_USER="" KBUILD_BUILD_HOST="" KBUILD_BUILD_TIMESTAMP="Thu May  8 13:27:41 2025" KBUILD_BUILD_VERSION="0" KBUILD_HOSTLDFLAGS="-L/home/mfw/openwrt/staging_dir/host/lib" CONFIG_SHELL="bash" V=''  cmd_syscalls=  KERNELRELEASE=5.15.180 CC="x86_64-openwrt-linux-musl-gcc" bzImage modules
make[5]: Entering directory '/home/mfw/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-5.15.180'
  CALL    scripts/checksyscalls.sh
  CALL    scripts/atomic/check-atomics.sh
  DESCEND objtool
  CHK     include/generated/compile.h
  CC      init/version.o
./tools/objtool/objtool: error while loading shared libraries: libelf.so.1: cannot open shared object file: No such file or directory
make[6]: *** [scripts/Makefile.build:289: init/version.o] Error 127
make[6]: *** Deleting file 'init/version.o'
```