### PR TITLE
[EFW-1402] Redefine tests/renovate-json5

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -283,8 +283,8 @@ images:
         - /var/lib    # for apt
         - /var/log    # for apt
     units:
-      - image: barney.ci/debian%minbase
       - image: barney.ci/debian%network
+      - image: barney.ci/debian%pkg/node-json5
 
   tests/renovate-json5:
     units:
@@ -292,9 +292,7 @@ images:
         sources:
           - code.arista.io/mfw/build # to get sources under stable path
         quota:
-          memory: 0.5Gi
-          cpu: 1.5
+          memory: 25Mi
+          cpu: 1
         build: |
-          apt update
-          apt install -y node-json5
           json5 --validate /src/code.arista.io/mfw/build/renovate.json5


### PR DESCRIPTION
[EFW-1402 https://awakesecurity.atlassian.net/browse/EFW-1402](https://awakesecurity.atlassian.net/browse/EFW-1402)


Redefine `tests/renovate-json5` to avoid a direct call to `apt install` in favour of `barney.ci/debian%pkg/`. The main purpose is to provide more stable resource usage, better fitting the new quota system.