### PR TITLE
EFW-1418_Barney_fix_memory_allocation

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -39,7 +39,7 @@ images:
     units:
       - floor: .%build-floor
         quota:
-          memory: 100Mi
+          memory: 500Mi
           cpu: 1
         build: |
           curl --version
@@ -77,7 +77,7 @@ images:
     units:
       - floor: .%toolchain
         quota:
-          memory: 0.01Gi
+          memory: 500Mi
           cpu: 1
         build: |
           /mfw-toolchain/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/bin/x86_64-openwrt-linux-musl-gcc --version
@@ -112,7 +112,7 @@ images:
     units:
       - floor: .%toolchain-glibc
         quota:
-          memory: 0.01Gi
+          memory: 500Mi
           cpu: 1
         build: |
           /mfw-toolchain/staging_dir/toolchain-x86_64_gcc-8.4.0_glibc/bin/x86_64-openwrt-linux-gnu-gcc --version
@@ -146,7 +146,7 @@ images:
     units:
       - floor: .%golang
         quota:
-          memory: 0.03Gi
+          memory: 500Mi
           cpu: 1
         build: |
           /mfw-toolchain/staging_dir/hostpkg/bin/go version
@@ -181,7 +181,7 @@ images:
     units:
       - floor: .%golang-glibc
         quota:
-          memory: 0.02Gi
+          memory: 500Mi
           cpu: 1
         build: |
           /mfw-toolchain/staging_dir/hostpkg/bin/go version
@@ -220,7 +220,7 @@ images:
     units:
       - floor: .%world
         quota:
-          memory: 0.01Gi
+          memory: 500Mi
           cpu: 1
         build: |
           date
@@ -261,7 +261,7 @@ images:
     units:
       - floor: .%world-glibc
         quota:
-          memory: 0.01Gi
+          memory: 500Mi
           cpu: 1
         build: |
           date
@@ -292,7 +292,7 @@ images:
         sources:
           - code.arista.io/mfw/build # to get sources under stable path
         quota:
-          memory: 25Mi
+          memory: 500Mi
           cpu: 1
         build: |
           json5 --validate /src/code.arista.io/mfw/build/renovate.json5


### PR DESCRIPTION
[EFW-1418 Fix memory allocation for Barney images](https://awakesecurity.atlassian.net/browse/EFW-1418)

Too low memory quota might cause an error
```
building "code.arista.io/mfw/tests%tests/pre-merge[0]": running [sh -uxec 'ls ptest-suite '] on ref: builtin%bootstrap: failed to setup spacetime: bst exited before the setup program ran: exit status 137 Error sending the setup instructions: EOF
```

I spoke with the Barney team and got a recommendation to increase our image memory quota to 500 MiB. With more data about the actual usage in the future, we might consider decreasing it, but the current recommendation is at least 100 MiB.